### PR TITLE
Implemented texture updating feature

### DIFF
--- a/e2e/texture/index.goml
+++ b/e2e/texture/index.goml
@@ -1,7 +1,9 @@
 <goml>
   <image-texture src="./uv.jpg"/>
+  <material type="unlit" id="mat1" color="purple" texture="query(image-texture)"/>
   <scene>
     <camera/>
-    <mesh geometry="cube" color="yellow" texture="query(image-texture)" rotation="45d,45d,0"/>
+    <mesh geometry="cube" color="yellow" texture="query(image-texture)" position="1.5,0,0" rotation="45d,45d,0"/>
+    <mesh geometry="cube" material="#mat1" position="-1.5,0,0" rotation="45d,45d,0"/>
   </scene>
 </goml>

--- a/src/Components/MaterialComponent.ts
+++ b/src/Components/MaterialComponent.ts
@@ -4,9 +4,9 @@ import Material from "../Material/Material";
 import Component from "grimoirejs/ref/Node/Component";
 import IAttributeDeclaration from "grimoirejs/ref/Node/IAttributeDeclaration";
 import ResourceBase from "../Resource/ResourceBase";
+import MaterialContainerBase from "./MaterialContainerBase";
 
-
-export default class MaterialComponent extends Component {
+export default class MaterialComponent extends MaterialContainerBase {
     public static attributes: { [key: string]: IAttributeDeclaration } = {
         type: {
             converter: "String",
@@ -34,25 +34,7 @@ export default class MaterialComponent extends Component {
 
     private async _registerAttributes(): Promise<void> {
         this.material = await this.materialPromise;
-        for (let key in this.material.argumentDeclarations) {
-            this.__addAttribute(key, this.material.argumentDeclarations[key]);
-            let lastValue;
-            if (this.material.arguments[key] !== void 0) {
-                lastValue = this.material.arguments[key];
-            }
-            this.getAttributeRaw(key).watch((n) => {
-              this.material.setArgument(key, n);
-            }, true);
-            if (lastValue !== void 0) {
-                this.material.setArgument(key, lastValue);
-            }
-        }
-        for (let key in this.material.macroDeclarations) {
-            this.__addAttribute(key, this.material.macroDeclarations[key]);
-            this.getAttributeRaw(key).watch((v) => {
-                this.material.setMacroValue(key, v);
-            }, true);
-        }
+        this.__exposeMaterialParameters(this.material);
         this.ready = true;
     }
 }

--- a/src/Components/MaterialContainerBase.ts
+++ b/src/Components/MaterialContainerBase.ts
@@ -1,0 +1,36 @@
+import BasicComponent from "./BasicComponent";
+import Material from "../Material/Material";
+
+/**
+ * Base class for container component for material and material arguments.
+ * Basically used for MaterialComponent and MaterialContainerComponent
+ */
+export default class MaterialContainerBase extends BasicComponent {
+  /**
+   * Expose sepcified parameters as attribute parameters on this component
+   * @param {Material} material [description]
+   */
+  protected __exposeMaterialParameters(material: Material): void {
+    const lastArguments = material.arguments; // Inherit last material argument if exists
+    material.arguments = {};
+    for (let key in material.argumentDeclarations) {
+        this.__addAttribute(key, material.argumentDeclarations[key]);
+        try {
+            this.getAttributeRaw(key).watch((n) => {
+              material.setArgument(key, n);
+            }, true);
+            if (lastArguments[key] !== void 0) { // TODO need to compare last converter is same as current one
+                this.setAttribute(key, lastArguments[key]);
+            }
+        } catch (e) {
+            throw new Error(`Parsing variable failed`);
+        }
+    }
+    for (let key in material.macroDeclarations) {
+        this.__addAttribute(key, material.macroDeclarations[key]);
+        this.getAttributeRaw(key).watch((v) => {
+            material.setMacroValue(key, v);
+        }, true);
+    }
+  }
+}

--- a/src/Components/MeshRendererComponent.ts
+++ b/src/Components/MeshRendererComponent.ts
@@ -131,7 +131,6 @@ export default class MeshRenderer extends Component implements IRenderable {
         const renderArgs = <IMaterialArgument>{
             targetBuffer: this.targetBuffer,
             geometry: this.geometryInstance,
-            attributeValues: null,
             camera: args.camera,
             transform: this._transformComponent,
             buffers: args.buffers,
@@ -142,7 +141,6 @@ export default class MeshRenderer extends Component implements IRenderable {
             technique: args.technique,
             renderable: this
         };
-        renderArgs.attributeValues = this._materialContainer.materialArgs; //TODO should be deprecated
         this._materialContainer.material.draw(renderArgs);
         this.node.emit("render", args);
     }

--- a/src/Components/RenderQuadComponent.ts
+++ b/src/Components/RenderQuadComponent.ts
@@ -125,7 +125,6 @@ export default class RenderQuadComponent extends Component {
     const renderArgs = <IMaterialArgument>{
       targetBuffer: this._targetBuffer,
       geometry: this._geom,
-      attributeValues: {},
       camera: null,
       transform: null,
       buffers: args.buffers,
@@ -133,7 +132,6 @@ export default class RenderQuadComponent extends Component {
       technique: this._technique,
       sceneDescription: {}
     };
-    renderArgs.attributeValues = this._materialContainer.materialArgs;
     // do render
     this._materialContainer.material.draw(renderArgs);
     this._gl.flush();

--- a/src/Material/IMaterialArgument.ts
+++ b/src/Material/IMaterialArgument.ts
@@ -7,7 +7,6 @@ import Geometry from "../Geometry/Geometry";
 interface IMaterialArgument {
   targetBuffer: string;
   geometry: Geometry;
-  attributeValues: { [key: string]: any };
   sceneDescription: { [key: string]: any };
   camera: CameraComponent;
   viewport: Rectangle;

--- a/src/Material/Material.ts
+++ b/src/Material/Material.ts
@@ -11,13 +11,13 @@ export default class Material {
 
     /**
      * Material arguments.
-     * Thease are mainly created by USER_VALUE semantics.
+     * These are mainly created by USER_VALUE semantics.
      */
     public argumentDeclarations: { [key: string]: IAttributeDeclaration } = {};
 
     /**
      * Values of materila arguments.
-     * Thease values would be passed to GPU for rendering.
+     * These values would be passed to GPU for rendering.
      */
     public arguments: { [key: string]: any } = {};
 


### PR DESCRIPTION
# Implemented several features on Texture2D

## Texture2D#getRawPixels():Uint8Array

Fetch all pixels of this texture2D as Uint8Array. This feature is only supporting RGBA format and UNSIGNED_BYTE format currently.

## Texture2D#get drawerContext:CanvasRenderingContext2D
## Texture2D#applyDraw():void

`drawerContext` is a canvas2D context for editing texture directly. This variable is only created on first access to the texture. This interface can be slow when firstly called this interface since this cause full texture copy into canvas2d texture context.

Once drawerContext was fetched, users can edit texture2D by simply calling canvas2D methods on drawerContext. `applyDraw` need to be called when update texture using drawerContext.

Example: 

```xml
<goml>
  <image-texture src="./uv.jpg"/>
  <material type="unlit" id="mat1" color="purple" texture="query(image-texture)"/>
  <scene>
    <camera/>
    <mesh geometry="cube" color="yellow" texture="query(image-texture)" position="1.5,0,0" rotation="45d,45d,0"/>
    <mesh geometry="cube" material="#mat1" position="-1.5,0,0" rotation="45d,45d,0"/>
  </scene>
</goml>
```

```js
const tex = gr("*")("image-texture").first().getComponent("Texture").texture;
const ctx = tex.drawerContext;
ctx.fillStyle = "red";
ctx.fillRect(100,100,200,300);
tex.applyDraw();
```
